### PR TITLE
Remove unnecessary stdlib dependency due to plugin update

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
 
     implementation(libs.androidx.activity.ktx)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.stdlib)
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.activity.compose)

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -33,7 +33,6 @@ android {
 dependencies {
     implementation(libs.androidx.activity.ktx)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.stdlib)
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.activity.compose)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graph
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
It used to be defined in order to specify kotlin's version manually but now alias(libs.plugins.kotlin.android) takes care of it so the stdlib dependency is not needed anymore